### PR TITLE
Updated license to "UNLICENSED" because it is

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/project-gustave/gustave-api.git"
   },
   "author": "Dan Conrad <dan.m.conrad@gmail.com> (http://www.danmconrad.com/)",
-  "license": "ISC",
+  "license": "UNLICENSED",
   "bugs": {
     "url": "https://github.com/project-gustave/gustave-api/issues"
   },


### PR DESCRIPTION
Obvious ex-lawyer jokes aside, this is the proper license setting in NPM for code you don't want to grant any license to. NPM init will only accept if all caps, btw. 